### PR TITLE
ci: fail fast on hung tests instead of running to the 6h job cap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,10 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    # A hung test previously ran to GitHub's 6h default job cap before
+    # failing, blocking the auto-merge check with no useful signal in
+    # the meantime. Fail fast instead.
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "tail-fweb": "bin/tail-fweb"
   },
   "scripts": {
-    "test": "node --test --test-force-exit test/index.test.js"
+    "test": "node --test --test-force-exit --test-timeout=15000 test/index.test.js"
   },
   "keywords": [
     "tail",


### PR DESCRIPTION
## Summary
- \`node --test\` had no per-test timeout, so a hung test (as happened on #8) ran until GitHub's 6-hour default job cap killed it, with no useful signal in the meantime.
- Adds \`--test-timeout=15000\` to the test script and \`timeout-minutes: 5\` to the CI job as a backstop, so a stuck test fails fast with a stack trace instead.

## Test plan
- [x] \`npm test\` passes locally (16/16)
- [ ] CI run on this PR completes well under 5 minutes