### PR TITLE
fix: replace nodejs-tail to close a lost-line race hanging CI

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,7 +2,7 @@
 
 const express     = require('express');
 const { Server }  = require('socket.io');
-const Tail        = require('nodejs-tail');
+const Tail        = require('./tail');
 const fs          = require('fs');
 const generateHtml = require('./html');
 

--- a/lib/tail.js
+++ b/lib/tail.js
@@ -1,0 +1,88 @@
+'use strict';
+
+const fs = require('fs');
+const EventEmitter = require('events');
+
+/**
+ * Watches a file and emits a 'line' event for each line appended to it.
+ *
+ * Replaces the nodejs-tail dependency, which stores the in-flight read's
+ * file descriptor on `this` - two 'change' events firing close together
+ * (routine under Linux inotify) let the second overwrite that field before
+ * the first read's callback runs, so the first callback closes the wrong
+ * fd, the first read errors, and the error handler silently drops the
+ * line. Reads here use only locals, and a queued in-flight flag stops two
+ * reads from running at once, so no event can be lost that way.
+ */
+class Tail extends EventEmitter {
+  constructor(filename) {
+    super();
+    this.filename = filename;
+    this._watcher = null;
+    this._lastSize = 0;
+    this._reading = false;
+    this._pending = false;
+  }
+
+  watch() {
+    this._lastSize = fs.statSync(this.filename).size;
+    this._watcher = fs.watch(this.filename, { persistent: true }, (eventType) => {
+      if (eventType !== 'change') return;
+      this._scheduleRead();
+    });
+  }
+
+  _scheduleRead() {
+    if (this._reading) {
+      this._pending = true;
+      return;
+    }
+    this._reading = true;
+    this._readNewData(() => {
+      this._reading = false;
+      if (this._pending) {
+        this._pending = false;
+        this._scheduleRead();
+      }
+    });
+  }
+
+  _readNewData(done) {
+    fs.stat(this.filename, (statErr, stats) => {
+      if (statErr) return done();
+
+      const diff = stats.size - this._lastSize;
+      if (diff <= 0) {
+        this._lastSize = stats.size;
+        return done();
+      }
+
+      const start = this._lastSize;
+      this._lastSize = stats.size;
+      const buffer = Buffer.alloc(diff);
+
+      fs.open(this.filename, 'r', (openErr, fd) => {
+        if (openErr) return done();
+        fs.read(fd, buffer, 0, diff, start, (readErr) => {
+          fs.close(fd, () => {});
+          if (readErr) return done();
+          buffer.toString('utf8').split('\n').forEach((line) => {
+            const trimmed = line.replace(/\r$/, '');
+            if (trimmed) this.emit('line', trimmed);
+          });
+          done();
+        });
+      });
+    });
+  }
+
+  close() {
+    if (this._watcher) {
+      this._watcher.close();
+      this._watcher = null;
+    }
+    this.emit('close');
+  }
+}
+
+module.exports = Tail;

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "command-line-args": "^6.0.1",
         "express": "^4.22.2",
         "morgan": "^1.10.1",
-        "nodejs-tail": "^1.1.1",
         "socket.io": "^4.8.1"
       },
       "bin": {
@@ -69,18 +68,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/anymatch": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
-      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
-      "dependencies": {
-        "normalize-path": "^3.0.0",
-        "picomatch": "^2.0.4"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/array-back": {
       "version": "6.2.3",
       "resolved": "https://registry.npmjs.org/array-back/-/array-back-6.2.3.tgz",
@@ -119,14 +106,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-    },
-    "node_modules/binary-extensions": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
-      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/body-parser": {
       "version": "1.20.5",
@@ -181,17 +160,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/braces": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
-      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "dependencies": {
-        "fill-range": "^7.1.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -228,26 +196,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/chokidar": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.3.tgz",
-      "integrity": "sha512-DtM3g7juCXQxFVSNPNByEC2+NImtBuxQQvWlHunpJIS5Ocr0lG306cC7FCi7cEA0fzmybPUIl4txBIobk1gGOQ==",
-      "dependencies": {
-        "anymatch": "~3.1.1",
-        "braces": "~3.0.2",
-        "glob-parent": "~5.1.0",
-        "is-binary-path": "~2.1.0",
-        "is-glob": "~4.0.1",
-        "normalize-path": "~3.0.0",
-        "readdirp": "~3.5.0"
-      },
-      "engines": {
-        "node": ">= 8.10.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.1.2"
       }
     },
     "node_modules/command-line-args": {
@@ -566,17 +514,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/fill-range": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
-      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "dependencies": {
-        "to-regex-range": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/finalhandler": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
@@ -629,20 +566,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/fsevents": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
-      "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
-      "deprecated": "\"Please update to latest v2.3 or v2.2\"",
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -687,17 +610,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dependencies": {
-        "is-glob": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/gopd": {
@@ -776,44 +688,6 @@
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
       "engines": {
         "node": ">= 0.10"
-      }
-    },
-    "node_modules/is-binary-path": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
-      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-      "dependencies": {
-        "binary-extensions": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/is-extglob": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-glob": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
-      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dependencies": {
-        "is-extglob": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-number": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "engines": {
-        "node": ">=0.12.0"
       }
     },
     "node_modules/lodash.camelcase": {
@@ -920,22 +794,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/nodejs-tail": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/nodejs-tail/-/nodejs-tail-1.1.1.tgz",
-      "integrity": "sha512-SMFsSeFT12XnLRtt2KPsCmnWcQ6ON79R6vW47svdr24YQulb6ugZy4gW6Db/icGm2vYRkfANLebV77L8poKzAg==",
-      "dependencies": {
-        "chokidar": "3.4.3"
-      }
-    },
-    "node_modules/normalize-path": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -992,18 +850,6 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
       "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
       "license": "MIT"
-    },
-    "node_modules/picomatch": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
@@ -1083,17 +929,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/readdirp": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
-      "integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
-      "dependencies": {
-        "picomatch": "^2.2.1"
-      },
-      "engines": {
-        "node": ">=8.10.0"
       }
     },
     "node_modules/safe-buffer": {
@@ -1411,17 +1246,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/to-regex-range": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dependencies": {
-        "is-number": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=8.0"
       }
     },
     "node_modules/toidentifier": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "command-line-args": "^6.0.1",
     "express": "^4.22.2",
     "morgan": "^1.10.1",
-    "nodejs-tail": "^1.1.1",
     "socket.io": "^4.8.1"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- Root cause of the hang on #8 (and reproducing on every CI run against `main`, unrelated to the express bump): `nodejs-tail` stores its in-flight read fd on `this`, so two `change` events firing close together let the second overwrite it before the first read's callback runs - the first callback closes the wrong fd, that read errors, and the error is silently swallowed, dropping a `line` event. The `maxLines` websocket test was waiting on exactly one of those dropped events.
- Replaces the dependency with a small in-repo watcher (`lib/tail.js`) using only local variables per read, plus a queue flag so concurrent `change` events never overlap.
- Drops the `nodejs-tail` dependency entirely.

## Test plan
- [x] `npm test` passes locally, 16/16, run 3x in a row
- [ ] CI green on this PR (will re-run a couple times to confirm the hang is actually gone, not just less likely)