### PR TITLE
chore(release): 2.2.0 - Express 5, dropped-line race fix, CI reliability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tail-fweb",
-  "version": "2.1.2",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tail-fweb",
-      "version": "2.1.2",
+      "version": "2.2.0",
       "license": "MIT",
       "dependencies": {
         "command-line-args": "^6.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tail-fweb",
-  "version": "2.1.2",
+  "version": "2.2.0",
   "description": "tail -f but streamed to a browser. Use as a CLI or embed as Express middleware.",
   "main": "lib/index.js",
   "repository": {


### PR DESCRIPTION
## Summary
One-time manual version bump to actually publish everything merged since 2.1.2 (express 5 upgrade, the nodejs-tail race fix, CI timeout reliability, cross-version host test) - none of it went out because the version field never changed and publish.yml only fires on that.

This is the last manual bump. A follow-up PR replaces publish.yml with semantic-release so future merges to main release automatically from conventional-commit types, no version editing required.

## Test plan
- [x] `npm test` passes locally (17/17)
- [ ] CI green
- [ ] Confirm publish.yml actually publishes 2.2.0 to npm after merge