### PR TITLE
ci: bump release job to Node 22, semantic-release requires it

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,12 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          # semantic-release itself requires Node >=22.14 - independent
+          # of the package's own `engines` field (Node >=18), which is
+          # what ci.yml's own Node 20 run validates against. This job
+          # doesn't run the test suite; it only runs after CI already
+          # passed on that older, consumer-matching Node version.
+          node-version: '22'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Ensure npm CLI supports trusted publishing (>= 11.5.1)


### PR DESCRIPTION
## Summary
First release.yml run failed immediately: \`semantic-release@25\` requires Node \`^22.14.0 || >=24.10.0\`, but the job was pinned to Node 20 (matching ci.yml). Bumps just this job to Node 22 - it doesn't run the test suite itself (that already happened in the CI run this workflow chains off via workflow_run), so this doesn't affect what Node version the package is actually validated against for consumers.

\`ci:\` prefix - no package code changed, shouldn't trigger a release.

## Test plan
- [ ] CI green
- [ ] release.yml run after this merges completes successfully (no release expected, ci: doesn't trigger one)